### PR TITLE
Add ignore statement to docs to prevent api-runner-browser.js error

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -23,6 +23,7 @@ browsers.
 
 Gatsby ships with a default .babelrc setup that should work for most sites. If you'd like
 to add custom Babel presets or plugins, you can create your own `.babelrc` at the root of your site, import [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby), and overwrite the `targets` option.
+Note that the api-runner-browser.js file will need to be ignored as shown below.
 
 ```shell
 npm install --save-dev babel-preset-gatsby
@@ -40,9 +41,12 @@ npm install --save-dev babel-preset-gatsby
         }
       }
     ]
-  ]
+  ],
+  "ignore": ['.cache/api-runner-browser.js']
 }
 ```
 <!-- prettier-ignore-end -->
 
 For more advanced configurations, you can also copy the defaults from [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby) and customize them to suit your needs.
+
+


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

A number of previous issues reference the error:

`
ReferenceError: exports is not defined in api-runner-browser.js
`
If no custom version of gatsby-browser.js has been created then this error still occurs whenever a simple `.babelrc` file is used. I have added the ignore statement to the docs to reflect this so that others do not need to sepnd time searching for this solution or implement a custom api-runner-browser.js.


## Related Issues
https://github.com/gatsbyjs/gatsby/issues/6958
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
